### PR TITLE
Add missing doc block to be shown in Storybook, code styling

### DIFF
--- a/lib/Button/Button.test.tsx
+++ b/lib/Button/Button.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { Button } from "./Button";

--- a/lib/Button/Button.tsx
+++ b/lib/Button/Button.tsx
@@ -9,6 +9,11 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconPosition?: "left" | "right";
 }
 
+/**
+ * Button atom component.
+ * Renders a styled button with support for variants, sizes, and optional icons.
+ * Uses Tailwind for styling and supports accessibility, custom classes, and disabled state.
+ */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {

--- a/lib/ErrorMessage/ErrorMessage.test.tsx
+++ b/lib/ErrorMessage/ErrorMessage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+
 import { ErrorMessage } from "./ErrorMessage";
 
 describe("ErrorMessage", () => {

--- a/lib/ErrorMessage/ErrorMessage.tsx
+++ b/lib/ErrorMessage/ErrorMessage.tsx
@@ -8,6 +8,11 @@ export interface ErrorMessageProps
   className?: string;
 }
 
+/**
+ * ErrorMessage atom component.
+ * Displays an accessible error message below a form field.
+ * Renders nothing if no children are provided and sets `role="alert"` for screen readers.
+ */
 export const ErrorMessage = ({
   id,
   children,

--- a/lib/HelperText/HelperText.stories.tsx
+++ b/lib/HelperText/HelperText.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+
 import { HelperText } from "./HelperText";
 
 const meta = {

--- a/lib/HelperText/HelperText.test.tsx
+++ b/lib/HelperText/HelperText.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+
 import { HelperText } from "./HelperText";
 
 describe("HelperText", () => {

--- a/lib/HelperText/HelperText.tsx
+++ b/lib/HelperText/HelperText.tsx
@@ -8,6 +8,11 @@ export interface HelperTextProps
   className?: string;
 }
 
+/**
+ * HelperText atom component.
+ * Provides additional context or guidance below a form field.
+ * Renders nothing if no content is passed and uses `role="note"` for accessibility.
+ */
 export const HelperText = ({
   id,
   children,

--- a/lib/IconButton/IconButton.test.tsx
+++ b/lib/IconButton/IconButton.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+
 import { IconButton } from "./IconButton";
 
 describe("IconButton", () => {

--- a/lib/IconButton/IconButton.tsx
+++ b/lib/IconButton/IconButton.tsx
@@ -4,11 +4,16 @@ import clsx from "clsx";
 export interface IconButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon: React.ReactNode;
-  "aria-label": string; // required for accessibility
+  "aria-label": string;
   size?: "sm" | "md" | "lg";
   variant?: "primary" | "secondary" | "tertiary";
 }
 
+/**
+ * IconButton atom component.
+ * Renders a button containing only an icon, with variant and size support.
+ * Requires an `aria-label` for accessibility and is styled with Tailwind CSS.
+ */
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {

--- a/lib/Input/Input.stories.tsx
+++ b/lib/Input/Input.stories.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
+
 import { Input } from "./Input";
 
 const meta: Meta<typeof Input> = {

--- a/lib/Input/Input.tsx
+++ b/lib/Input/Input.tsx
@@ -4,6 +4,11 @@ import clsx from "clsx";
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
+/**
+ * Input atom component.
+ * Renders a styled text input with support for disabled and read-only states.
+ * Uses Tailwind CSS for styling and supports all native input attributes.
+ */
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => {
     return (

--- a/lib/InputField/InputField.tsx
+++ b/lib/InputField/InputField.tsx
@@ -11,6 +11,11 @@ export interface InputFieldProps extends React.ComponentProps<typeof Input> {
   helperText?: string;
 }
 
+/**
+ * InputField molecule component.
+ * Combines Label, Input, HelperText, and ErrorMessage into a single accessible form field.
+ * Manages ARIA attributes for error and helper text associations.
+ */
 export const InputField = ({
   id,
   label,

--- a/lib/Label/Label.test.tsx
+++ b/lib/Label/Label.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+
 import { Label } from "./Label";
 import { Input } from "../Input/Input";
 

--- a/lib/Label/Label.tsx
+++ b/lib/Label/Label.tsx
@@ -7,6 +7,11 @@ export interface LabelProps
   children?: React.ReactNode;
 }
 
+/**
+ * Label atom component.
+ * Renders a styled label linked to a form input via htmlFor.
+ * Returns null if no children are provided.
+ */
 export const Label = ({
   htmlFor,
   children,

--- a/lib/Tooltip/Tooltip.tsx
+++ b/lib/Tooltip/Tooltip.tsx
@@ -10,6 +10,11 @@ export interface TooltipProps {
   position?: "top" | "bottom" | "left" | "right";
 }
 
+/**
+ * Tooltip atom component.
+ * Displays a tooltip with customizable content and position on hover or focus.
+ * Adds ARIA attributes for accessibility and supports configurable show delay.
+ */
 export const Tooltip = ({
   children,
   content,


### PR DESCRIPTION
- Add missing component descriptions to be displaye in Storybook
- Separate 3rd party from local imports
- Remove unused imports