### PR TITLE
Fix deploy storybook workflow

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,19 +1,22 @@
-import type { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  "stories": [
-    "../lib/**/*.mdx",
-    "../lib/**/*.stories.@(js|jsx|mjs|ts|tsx)"
-  ],
-  "addons": [
+  stories: ["../lib/**/*.mdx", "../lib/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: [
     "@chromatic-com/storybook",
     "@storybook/addon-docs",
     "@storybook/addon-a11y",
-    "@storybook/addon-vitest"
+    "@storybook/addon-vitest",
   ],
-  "framework": {
-    "name": "@storybook/react-vite",
-    "options": {}
-  }
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  viteFinal: (config, { configType }) => {
+    if (configType === "PRODUCTION") {
+      config.base = "/another-react-component-library/";
+    }
+    return config;
+  },
 };
 export default config;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build --base-path /another-react-component-library/"
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",


### PR DESCRIPTION
## 🚀 What’s new?

The workflow to deploy the new build of the storybook didn't work because of a param that doesn't exist
<img width="549" alt="Screen Shot 2025-06-16 at 20 54 57" src="https://github.com/user-attachments/assets/97046ce1-a545-4d0e-abb8-9c0c3f5fbb78" />

## ✅ Definition of Done

A component is **done** when:

- [ ] Follows Component-Driven Development
- [ ] Typed with defaults
- [ ] Uses Tailwind CSS
- [ ] Supports `className` for custom styles
- [ ] Component is documented and has Storybook stories
- [ ] Has unit tests and tests are passing
- [ ] Passes build
- [ ] Aria compliant (accessible)
- [ ] Component is exported
