### PR TITLE
Refactor Input and InputField to accept an inner Icon

### DIFF
--- a/lib/Icon/Icon.tests.tsx
+++ b/lib/Icon/Icon.tests.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Icon } from "./Icon";
+import { Home } from "lucide-react";
+
+describe("Icon component", () => {
+  it("renders the icon with role img and accessible name", () => {
+    render(<Icon icon={<Home />} aria-label="Home icon" />);
+    const iconWrapper = screen.getByRole("img", { name: "Home icon" });
+    expect(iconWrapper).toBeInTheDocument();
+
+    // The SVG inside should be present as child element
+    const svgElement = iconWrapper.querySelector("svg");
+    expect(svgElement).toBeInTheDocument();
+  });
+
+  it("renders decorative icon with aria-hidden=true and no role", () => {
+    render(<Icon icon={<Home />} />);
+    // Since no aria-label, role img is not set
+    // Use container query for span with aria-hidden true
+    const iconWrapper = screen.getByRole("presentation", { hidden: true });
+    // But role "presentation" is not explicitly set in your component
+    // So query by span with aria-hidden true
+    const spanElement = screen.getByText(
+      (content, element) => element?.getAttribute("aria-hidden") === "true"
+    );
+    expect(spanElement).toBeInTheDocument();
+    expect(spanElement).not.toHaveAttribute("role");
+  });
+
+  it("applies size and color styles correctly", () => {
+    render(
+      <Icon icon={<Home />} size={32} color="red" aria-label="Home icon" />
+    );
+    const iconWrapper = screen.getByRole("img", { name: "Home icon" });
+    expect(iconWrapper).toHaveStyle({
+      width: "32px",
+      height: "32px",
+      color: "red",
+    });
+
+    const svgElement = iconWrapper.querySelector("svg");
+    expect(svgElement).toHaveAttribute("color", "red");
+    expect(svgElement).toHaveAttribute("width", "32");
+    expect(svgElement).toHaveAttribute("height", "32");
+  });
+});

--- a/lib/Input/Input.stories.tsx
+++ b/lib/Input/Input.stories.tsx
@@ -1,9 +1,11 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { Search, Send } from "lucide-react";
 
 import { Input } from "./Input";
+import { Icon } from "../Icon/Icon";
 
 const meta: Meta<typeof Input> = {
-  title: "atoms/Input",
+  title: "molecules/Input",
   component: Input,
   parameters: {
     layout: "centered",
@@ -61,5 +63,21 @@ export const Invalid: Story = {
   args: {
     "aria-invalid": true,
     placeholder: "Invalid input",
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    placeholder: "Search...",
+    icon: <Icon icon={<Search />} size={18} />,
+    iconPosition: "left",
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    placeholder: "Search...",
+    icon: <Icon icon={<Send />} size={18} />,
+    iconPosition: "right",
   },
 };

--- a/lib/Input/Input.test.tsx
+++ b/lib/Input/Input.test.tsx
@@ -4,12 +4,19 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Input } from "./Input";
+import { Search } from "lucide-react";
 
 describe("Input", () => {
+  it("renders without crashing", () => {
+    render(<Input aria-label="input-field" />);
+    expect(
+      screen.getByRole("textbox", { name: "input-field" })
+    ).toBeInTheDocument();
+  });
+
   it("renders input with placeholder", () => {
     render(<Input placeholder="Enter text" aria-label="input-field" />);
     const input = screen.getByRole("textbox", { name: "input-field" });
-    expect(input).toBeInTheDocument();
     expect(input).toHaveAttribute("placeholder", "Enter text");
   });
 
@@ -22,25 +29,50 @@ describe("Input", () => {
 
   it("supports disabling", () => {
     render(<Input disabled aria-label="input-field" />);
-    const input = screen.getByRole("textbox", { name: "input-field" });
-    expect(input).toBeDisabled();
+    expect(screen.getByRole("textbox", { name: "input-field" })).toBeDisabled();
   });
 
   it("supports readOnly", () => {
     render(<Input readOnly aria-label="input-field" />);
-    const input = screen.getByRole("textbox", { name: "input-field" });
-    expect(input).toHaveAttribute("readonly");
+    expect(
+      screen.getByRole("textbox", { name: "input-field" })
+    ).toHaveAttribute("readonly");
   });
 
   it("applies custom className", () => {
     render(<Input className="custom-class" aria-label="input-field" />);
-    const input = screen.getByRole("textbox", { name: "input-field" });
-    expect(input).toHaveClass("custom-class");
+    expect(screen.getByRole("textbox", { name: "input-field" })).toHaveClass(
+      "custom-class"
+    );
   });
 
   it("forwards ref correctly", () => {
     const ref = React.createRef<HTMLInputElement>();
     render(<Input ref={ref} aria-label="input-field" />);
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("renders icon on the left by default", () => {
+    render(
+      <Input icon={<Search data-testid="icon" />} aria-label="input-field" />
+    );
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("renders icon on the right when iconPosition is right", () => {
+    render(
+      <Input
+        icon={<Search data-testid="icon" />}
+        iconPosition="right"
+        aria-label="input-field"
+      />
+    );
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("removes left padding when no icon is passed", () => {
+    render(<Input aria-label="input-field" />);
+    const input = screen.getByRole("textbox", { name: "input-field" });
+    expect(input.className.includes("pl-10")).toBe(false);
   });
 });

--- a/lib/Input/Input.tsx
+++ b/lib/Input/Input.tsx
@@ -1,28 +1,62 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, ReactElement } from "react";
 import clsx from "clsx";
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  icon?: ReactElement;
+  iconPosition?: "left" | "right";
+}
 
 /**
- * Input atom component.
- * Renders a styled text input with support for disabled and read-only states.
+ * Input molecule component.
+ * Renders a styled input with optional icon on left or right.
+ * Support for disabled and read-only states.
  * Uses Tailwind CSS for styling and supports all native input attributes.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, ...props }, ref) => {
+  (
+    { icon, iconPosition = "left", className, disabled, readOnly, ...props },
+    ref
+  ) => {
+    const hasIcon = Boolean(icon);
+
+    const containerClass = clsx(
+      "relative flex items-center",
+      disabled && "opacity-60 cursor-not-allowed"
+    );
+
+    const inputClass = clsx(
+      "block rounded-md border px-3 py-2 text-sm shadow-sm w-full",
+      hasIcon && iconPosition === "left" && "pl-10",
+      hasIcon && iconPosition === "right" && "pr-10",
+      "focus:outline-none focus:ring-2 focus:ring-blue-500",
+      disabled && "bg-gray-100 cursor-not-allowed",
+      readOnly && "bg-gray-50 text-gray-500",
+      className
+    );
+
+    const iconWrapperClass = clsx(
+      "absolute inset-y-0 flex items-center",
+      iconPosition === "left" ? "left-3" : "right-3",
+      disabled && "text-gray-400",
+      !disabled && "text-gray-500"
+    );
+
     return (
-      <input
-        ref={ref}
-        className={clsx(
-          "block rounded-md border px-3 py-2 text-sm shadow-sm",
-          "focus:outline-none focus:ring-2 focus:ring-blue-500",
-          props.disabled && "bg-gray-100 cursor-not-allowed",
-          props.readOnly && "bg-gray-50 text-gray-500",
-          className
+      <div className={containerClass}>
+        {hasIcon && (
+          <span className={iconWrapperClass} aria-hidden="true">
+            {icon}
+          </span>
         )}
-        {...props}
-      />
+        <input
+          ref={ref}
+          disabled={disabled}
+          readOnly={readOnly}
+          className={inputClass}
+          {...props}
+        />
+      </div>
     );
   }
 );

--- a/lib/InputField/InputField.stories.tsx
+++ b/lib/InputField/InputField.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { MessageCircleWarning, User } from "lucide-react";
 
 import { InputField } from "./InputField";
+import { Icon } from "../Icon/Icon";
 
 const meta = {
   title: "molecules/InputField",
@@ -27,14 +29,36 @@ export const WithHelperText: Story = {
   },
 };
 
-export const WithError: Story = {
-  args: {
-    error: "Email is required",
-  },
-};
-
 export const Disabled: Story = {
   args: {
     disabled: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: "Username",
+    placeholder: "Enter your username",
+    icon: <Icon icon={<MessageCircleWarning />} size="sm" />,
+    iconPosition: "left",
+    error: "This field is required",
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    label: "Username",
+    placeholder: "Enter your username",
+    icon: <Icon icon={<User />} size="sm" />,
+    iconPosition: "left",
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    label: "Username",
+    placeholder: "Enter your username",
+    icon: <Icon icon={<User />} size="sm" />,
+    iconPosition: "right",
   },
 };

--- a/lib/InputField/InputField.test.tsx
+++ b/lib/InputField/InputField.test.tsx
@@ -1,10 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { Search } from "lucide-react";
 
 import { InputField } from "./InputField";
 
 describe("InputField", () => {
-  it("renders label, input, helperText", () => {
+  it("renders without crashing", () => {
+    render(<InputField label="Test" />);
+    expect(screen.getByLabelText("Test")).toBeInTheDocument();
+  });
+
+  it("renders label, input, and helperText", () => {
     render(
       <InputField
         label="Email"
@@ -20,12 +26,9 @@ describe("InputField", () => {
   });
 
   it("renders error message and aria attributes", () => {
-    render(
-      <InputField label="Email" error="Required" data-testid="inputfield" />
-    );
-
-    expect(screen.getByText("Required")).toBeInTheDocument();
+    render(<InputField label="Email" error="Required" />);
     const input = screen.getByLabelText("Email");
+    expect(screen.getByText("Required")).toBeInTheDocument();
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(input).toHaveAttribute("aria-describedby");
   });
@@ -45,15 +48,29 @@ describe("InputField", () => {
   });
 
   it("accepts and forwards className to input", () => {
-    render(
-      <InputField label="Email" className="w-64" data-testid="inputfield" />
-    );
-
+    render(<InputField label="Email" className="w-64" />);
     expect(screen.getByLabelText("Email")).toHaveClass("w-64");
   });
 
   it("supports disabled input", () => {
     render(<InputField label="Email" disabled />);
     expect(screen.getByLabelText("Email")).toBeDisabled();
+  });
+
+  it("renders icon if provided", () => {
+    render(
+      <InputField
+        label="Search"
+        icon={<Search data-testid="icon" />}
+        placeholder="Search..."
+      />
+    );
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("removes input padding when no icon is provided", () => {
+    render(<InputField label="Search" placeholder="Type..." />);
+    const input = screen.getByLabelText("Search");
+    expect(input.className.includes("pl-10")).toBe(false);
   });
 });

--- a/lib/InputField/InputField.tsx
+++ b/lib/InputField/InputField.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import clsx from "clsx";
 
 import { Label } from "../Label/Label";
 import { Input } from "../Input/Input";
@@ -15,6 +16,7 @@ export interface InputFieldProps extends React.ComponentProps<typeof Input> {
  * InputField molecule component.
  * Combines Label, Input, HelperText, and ErrorMessage into a single accessible form field.
  * Manages ARIA attributes for error and helper text associations.
+ * Delegates icon handling and padding fully to Input component.
  */
 export const InputField = ({
   id,
@@ -35,16 +37,19 @@ export const InputField = ({
   return (
     <div className="space-y-1">
       {label && <Label htmlFor={inputId}>{label}</Label>}
+
       <Input
         id={inputId}
         aria-invalid={!!error}
         aria-describedby={describedBy || undefined}
         className={className}
-        {...props}
+        {...props} // includes icon, iconPosition, etc.
       />
+
       {!error && helperText && (
         <HelperText id={`${inputId}-helper`}>{helperText}</HelperText>
       )}
+
       {error && <ErrorMessage id={`${inputId}-error`}>{error}</ErrorMessage>}
     </div>
   );


### PR DESCRIPTION
## 🚀 What’s new?

Add an icon inside the Input and InputField, manage the padding in Input, InputField forwards props

## ✅ Definition of Done

A component is **done** when:

- [x] Follows Component-Driven Development
- [x] Typed with defaults
- [x] Uses Tailwind CSS
- [x] Supports `className` for custom styles
- [x] Component is documented and has Storybook stories
- [x] Has unit tests and tests are passing
- [x] Passes build
- [x] Aria compliant (accessible)
- [x] Component is exported
