### PR TITLE
Full width root storybook decorator

### DIFF
--- a/.storybook/decorators/withFullWidthRoot.tsx
+++ b/.storybook/decorators/withFullWidthRoot.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import type { Decorator } from "@storybook/react";
+
+/**
+ * Sets `width: 100%` on the #storybook-root element for a specific story.
+ */
+export const withFullWidthRoot: Decorator = (Story) => {
+  useEffect(() => {
+    const root = document.getElementById("storybook-root");
+
+    if (root) root.style.width = "100%";
+
+    return () => {
+      if (root) root.style.width = "";
+    };
+  }, []);
+
+  return <Story />;
+};

--- a/lib/ProgressBar/ProgressBar.stories.tsx
+++ b/lib/ProgressBar/ProgressBar.stories.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ProgressBar } from "./ProgressBar";
+import { withFullWidthRoot } from "../../.storybook/decorators/withFullWidthRoot";
 
 const meta = {
   title: "atoms/ProgressBar",
@@ -21,6 +21,7 @@ const meta = {
     barClassName: { control: "text" },
     labelClassName: { control: "text" },
   },
+  decorators: [withFullWidthRoot],
 } satisfies Meta<typeof ProgressBar>;
 
 export default meta;


### PR DESCRIPTION
## Summary

Adds a `withFullWidthRoot` Storybook decorator that sets the `#storybook-root` element to `width: 100%` for components that require full-width rendering.

## Features

- Can be used per-story without affecting global layout.
- Ensures components like `ProgressBar` render in a responsive container.
- Cleans up styling on unmount to avoid side effects.

## Usage

Import and apply the decorator to your story:

```ts
import { withFullWidthRoot } from "../../../.storybook/decorators/withFullWidthRoot";

export const MyStory = {
  decorators: [withFullWidthRoot],
  args: { /* ... */ },
};