### PR TITLE
Tree Shaking lucide-react Icons with Vite and Vitest

### DIFF
--- a/lib/@types/lucide.d.ts
+++ b/lib/@types/lucide.d.ts
@@ -1,0 +1,8 @@
+declare module "lucide-react/icons/*" {
+  import { LucideProps } from "lucide-react";
+  import { FC } from "react";
+
+  const Icon: FC<LucideProps>;
+
+  export default Icon;
+}

--- a/lib/Spinner/Spinner.tsx
+++ b/lib/Spinner/Spinner.tsx
@@ -1,6 +1,6 @@
-import { LoaderCircle } from "lucide-react";
-import clsx from "clsx";
 import React from "react";
+import clsx from "clsx";
+import LoaderCircle from "lucide-react/icons/loader-circle";
 
 export interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: "sm" | "md" | "lg";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,4 +31,11 @@ export default defineConfig({
       },
     },
   },
+  resolve: {
+    alias: {
+      "lucide-react/icons": fileURLToPath(
+        new URL("./node_modules/lucide-react/dist/esm/icons", import.meta.url)
+      ),
+    },
+  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "url";
 
 const CI = process.env.CI === "true";
 
@@ -8,5 +9,12 @@ export default defineConfig({
     globals: true,
     setupFiles: "./vitest.setup.ts",
     reporters: CI ? [["default", { summary: false }]] : ["verbose"],
+  },
+  resolve: {
+    alias: {
+      "lucide-react/icons": fileURLToPath(
+        new URL("./node_modules/lucide-react/dist/esm/icons", import.meta.url)
+      ),
+    },
   },
 });


### PR DESCRIPTION
## 🚀 What’s new?

## Summary
While building the Spinner component, I noticed build time jumped from 5.6s to 0.784s and modules from 35 to 1,637 due to bundling all lucide-react icons.

## Issue
Vite doesn’t tree-shake lucide-react icons properly, causing large bundles and slow builds.

## Fix
- Added an alias in `vite.config.ts` and `vitest.config.ts` pointing to `lucide-react/dist/esm/icons`.
- Created `lucide.d.ts` to declare icon modules with React typings.
- Updated imports to use the alias.
