### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
     "typescript",
     "vite",
     "storybook"
-  ]
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
## 🚀 What’s new?
Set the license field in package.json to "MIT" to clearly specify that this project is licensed under the MIT License. This change ensures proper SPDX compliance and clarifies the licensing for users and tools.

