### PR TITLE
0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "another-react-component-library",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "another-react-component-library",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.10",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "another-react-component-library",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A customizable React 19 component library build with Vite, Tailwind CSS v4 and TypeScript.",
   "type": "module",
   "files": [


### PR DESCRIPTION
## 🚀 What’s new?
## [0.6.1] - Patch Release

### Changes

- **Tree shaking lucide-react icons** with Vite and Vitest to optimize bundle size and improve performance, contributed by [@casvil](https://github.com/casvil) in [#59](https://github.com/your-repo/your-project/pull/59)
- **Add MIT license** to `package.json` for clearer licensing information, contributed by [@casvil](https://github.com/casvil) in [#60](https://github.com/your-repo/your-project/pull/60)
