### PR TITLE
Fix branch name in CI workflow 🫠

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build-test:


### PR DESCRIPTION
## 🚀 What’s new?

CI badge was `no status` 