### PR TITLE
Override optional time omitted from TimeDisplayProps and fix story warnings

### DIFF
--- a/lib/Clock/Clock.stories.tsx
+++ b/lib/Clock/Clock.stories.tsx
@@ -53,8 +53,18 @@ export const CustomStyleDigital7Font = {
     <Clock {...args} className="digital7 text-4xl border-3 px-3 py-0" />
   ),
   args: {
-    time: new Date(),
     format: 'mm:ss',
     bordered: true,
+  },
+};
+
+export const Stopped = {
+  render: (args) => (
+    <Clock {...args} className="digital7 text-4xl border-3 px-3 py-0" />
+  ),
+  args: {
+    format: 'mm:ss',
+    bordered: true,
+    stop: true,
   },
 };

--- a/lib/Clock/Clock.tsx
+++ b/lib/Clock/Clock.tsx
@@ -1,26 +1,35 @@
 import { useEffect, useState, forwardRef } from 'react';
-
 import { TimeDisplay } from '../TimeDisplay/TimeDisplay';
 import type { TimeDisplayProps } from '../TimeDisplay/TimeDisplay';
+
+export interface ClockProps extends Omit<TimeDisplayProps, 'time'> {
+  /** If true, stops the internal clock updates */
+  stop?: boolean;
+}
 
 /**
  * Clock molecule component.
  * Renders a live-updating time string using TimeDisplay.
- * Updates every second and supports the same formatting and styling props than TimeDisplay.
+ * If `stop` is true, it stops updating.
  */
-export const Clock = forwardRef<HTMLTimeElement, TimeDisplayProps>(
-  ({ format, className, bordered = false }, ref) => {
-    const [time, setTime] = useState(new Date());
+export const Clock = forwardRef<HTMLTimeElement, ClockProps>(
+  ({ format = 'HH:mm:ss', className, bordered = false, stop = false }, ref) => {
+    const [time, setTime] = useState(() => new Date());
 
     useEffect(() => {
-      const timerId = setInterval(() => setTime(new Date()), 1000);
-      return () => clearInterval(timerId);
-    }, []);
+      if (stop) return;
+
+      const interval = setInterval(() => {
+        setTime(new Date());
+      }, 1000);
+
+      return () => clearInterval(interval);
+    }, [stop]);
 
     return (
       <TimeDisplay
         ref={ref}
-        time={time.toISOString()}
+        time={time}
         format={format}
         className={className}
         bordered={bordered}
@@ -28,3 +37,5 @@ export const Clock = forwardRef<HTMLTimeElement, TimeDisplayProps>(
     );
   },
 );
+
+Clock.displayName = 'Clock';


### PR DESCRIPTION
## 🚀 What’s new?

Clock stories were complaining because they were missing `time` 

- [x] Added time to ClockProps
- [ ] Add `stop` prop to Clock

## ✅ Definition of Done

A component is **done** when:

- [x] Follows Component-Driven Development
- [x] Typed with defaults
- [x] Uses Tailwind CSS
- [x] Supports `className` for custom styles
- [x] Component is documented and has Storybook stories
- [x] Has unit tests and tests are passing
- [x] Passes build
- [x] Aria compliant (accessible)
- [x] Component is exported
