### PR TITLE
Fix switch thumb translate positions

### DIFF
--- a/lib/@types/size.ts
+++ b/lib/@types/size.ts
@@ -59,7 +59,7 @@ export const switchSizeClasses = {
   sm: {
     track: 'w-9 h-5',
     thumb: 'w-4 h-4',
-    thumbTranslate: 'translate-x-5.5',
+    thumbTranslate: 'translate-x-4.5',
     thumbUnchecked: 'translate-x-0.5',
   },
   md: {
@@ -72,7 +72,7 @@ export const switchSizeClasses = {
     track: 'w-14 h-7',
     thumb: 'w-6 h-6',
     thumbTranslate: 'translate-x-7.5',
-    thumbUnchecked: 'translate-x-1',
+    thumbUnchecked: 'translate-x-0.5',
   },
 } as const;
 

--- a/lib/Switch/Switch.test.tsx
+++ b/lib/Switch/Switch.test.tsx
@@ -171,4 +171,25 @@ describe('Switch', () => {
     expect(input).toHaveAttribute('data-testid', 'custom-switch');
     expect(input).toHaveAttribute('aria-label', 'Custom switch');
   });
+
+  it('applies correct translate-x class for checked and unchecked states for all sizes', () => {
+    const sizes = [
+      { size: 'sm', unchecked: 'translate-x-0.5', checked: 'translate-x-4.5' },
+      { size: 'md', unchecked: 'translate-x-0.5', checked: 'translate-x-5.5' },
+      { size: 'lg', unchecked: 'translate-x-0.5', checked: 'translate-x-7.5' },
+    ];
+    const { rerender } = render(<Switch size="sm" checked={false} />);
+    sizes.forEach(({ size, unchecked, checked }) => {
+      rerender(<Switch size={size} checked={false} />);
+      const track = screen.getByRole('switch').nextElementSibling;
+      const thumb = track.querySelector('span');
+      expect(thumb).toHaveClass(unchecked);
+
+      rerender(<Switch size={size} checked={true} />);
+      const thumbChecked = screen
+        .getByRole('switch')
+        .nextElementSibling.querySelector('span');
+      expect(thumbChecked).toHaveClass(checked);
+    });
+  });
 });


### PR DESCRIPTION
## 🚀 What’s new?

Adjust translate x positions on checked and add tests accordingly

## ✅ Definition of Done

A component is **done** when:

- [x] Follows Component-Driven Development
- [x] Typed with defaults
- [x] Uses Tailwind CSS
- [x] Supports `className` for custom styles
- [x] Component is documented and has Storybook stories
- [x] Has unit tests and tests are passing
- [x] Passes build
- [x] Aria compliant (accessible)
- [x] Component is exported
