### PR TITLE
Complete LucideIcon standardization and Input component enhancement

### DIFF
--- a/lib/@types/size.ts
+++ b/lib/@types/size.ts
@@ -25,6 +25,29 @@ const iconSizeClasses = {
   lg: 'w-8 h-8',
 } as const;
 
+// Icon size values for Lucide icons (numeric values for size prop)
+export const iconSizeValues = {
+  sm: 16,
+  md: 20,
+  lg: 24,
+} as const;
+
+// Icon positioning classes for Input component
+const inputIconPositionClasses = {
+  sm: {
+    iconLeft: 'left-2',
+    iconRight: 'right-2',
+  },
+  md: {
+    iconLeft: 'left-3',
+    iconRight: 'right-3',
+  },
+  lg: {
+    iconLeft: 'left-4',
+    iconRight: 'right-4',
+  },
+} as const;
+
 const avatarSizeClassesRaw = {
   sm: 'w-8 h-8',
   md: 'w-12 h-12',
@@ -142,6 +165,29 @@ const createProgressBar = (
     lg: { label: text.lg, bar: height.lg },
   }) as const;
 
+// Helper function to create input icon positioning objects
+const createInputIconPosition = (
+  text: typeof textSizeClasses,
+  iconPosition: typeof inputIconPositionClasses,
+) =>
+  ({
+    sm: { 
+      icon: text.sm, 
+      iconLeft: iconPosition.sm.iconLeft, 
+      iconRight: iconPosition.sm.iconRight 
+    },
+    md: { 
+      icon: text.md, 
+      iconLeft: iconPosition.md.iconLeft, 
+      iconRight: iconPosition.md.iconRight 
+    },
+    lg: { 
+      icon: text.lg, 
+      iconLeft: iconPosition.lg.iconLeft, 
+      iconRight: iconPosition.lg.iconRight 
+    },
+  }) as const;
+
 // Export the computed size classes
 export const sizeClasses = textSizeClasses;
 
@@ -187,4 +233,9 @@ export const radioSizeClasses = createRadioControl(
 export const progressBarSizeClasses = createProgressBar(
   textSizeClasses,
   progressBarHeightSizeClasses,
+);
+
+export const inputIconSizeClasses = createInputIconPosition(
+  textSizeClasses,
+  inputIconPositionClasses,
 );

--- a/lib/@types/size.ts
+++ b/lib/@types/size.ts
@@ -32,7 +32,6 @@ export const iconSizeValues = {
   lg: 24,
 } as const;
 
-// Icon positioning classes for Input component
 const inputIconPositionClasses = {
   sm: {
     iconLeft: 'left-2',
@@ -171,20 +170,20 @@ const createInputIconPosition = (
   iconPosition: typeof inputIconPositionClasses,
 ) =>
   ({
-    sm: { 
-      icon: text.sm, 
-      iconLeft: iconPosition.sm.iconLeft, 
-      iconRight: iconPosition.sm.iconRight 
+    sm: {
+      icon: text.sm,
+      iconLeft: iconPosition.sm.iconLeft,
+      iconRight: iconPosition.sm.iconRight,
     },
-    md: { 
-      icon: text.md, 
-      iconLeft: iconPosition.md.iconLeft, 
-      iconRight: iconPosition.md.iconRight 
+    md: {
+      icon: text.md,
+      iconLeft: iconPosition.md.iconLeft,
+      iconRight: iconPosition.md.iconRight,
     },
-    lg: { 
-      icon: text.lg, 
-      iconLeft: iconPosition.lg.iconLeft, 
-      iconRight: iconPosition.lg.iconRight 
+    lg: {
+      icon: text.lg,
+      iconLeft: iconPosition.lg.iconLeft,
+      iconRight: iconPosition.lg.iconRight,
     },
   }) as const;
 

--- a/lib/atoms/Checkbox/Checkbox.tsx
+++ b/lib/atoms/Checkbox/Checkbox.tsx
@@ -48,7 +48,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     );
     const inputChecked = isControlled ? checked : internalChecked;
 
-    const handleChange = (e) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!isControlled) setInternalChecked(e.target.checked);
       if (rest.onChange) rest.onChange(e);
     };

--- a/lib/atoms/Input/Input.stories.tsx
+++ b/lib/atoms/Input/Input.stories.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Search, Send } from 'lucide-react';
 
 import { Input } from './Input';
-import { Icon } from '../Icon/Icon';
 
 const meta: Meta<typeof Input> = {
   title: 'atoms/Input',
@@ -70,7 +68,7 @@ export const Invalid: Story = {
 export const WithLeftIcon: Story = {
   args: {
     placeholder: 'Search...',
-    icon: <Icon icon={Search} size={18} />,
+    icon: Search,
     iconPosition: 'left',
   },
 };
@@ -78,7 +76,7 @@ export const WithLeftIcon: Story = {
 export const WithRightIcon: Story = {
   args: {
     placeholder: 'Search...',
-    icon: <Icon icon={Send} size={18} />,
+    icon: Send,
     iconPosition: 'right',
   },
 };

--- a/lib/atoms/Input/Input.test.tsx
+++ b/lib/atoms/Input/Input.test.tsx
@@ -54,21 +54,21 @@ describe('Input', () => {
   });
 
   it('renders icon on the left by default', () => {
-    render(
-      <Input icon={<Search data-testid="icon" />} aria-label="input-field" />,
-    );
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    render(<Input icon={Search} aria-label="input-field" />);
+    const iconContainer = screen
+      .getByRole('textbox', { name: 'input-field' })
+      .parentElement?.querySelector('span');
+    expect(iconContainer).toBeInTheDocument();
   });
 
   it('renders icon on the right when iconPosition is right', () => {
     render(
-      <Input
-        icon={<Search data-testid="icon" />}
-        iconPosition="right"
-        aria-label="input-field"
-      />,
+      <Input icon={Search} iconPosition="right" aria-label="input-field" />,
     );
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    const iconContainer = screen
+      .getByRole('textbox', { name: 'input-field' })
+      .parentElement?.querySelector('span');
+    expect(iconContainer).toBeInTheDocument();
   });
 
   it('removes left padding when no icon is passed', () => {

--- a/lib/atoms/Input/Input.tsx
+++ b/lib/atoms/Input/Input.tsx
@@ -1,13 +1,20 @@
 import React, { forwardRef, InputHTMLAttributes } from 'react';
 import clsx from 'clsx';
+import type { LucideIcon } from 'lucide-icon-type';
 
 import type { Size } from '../../@types/size';
-import { inputSizeClasses } from '../../@types/size';
+import {
+  inputSizeClasses,
+  iconSizeValues,
+  inputIconSizeClasses,
+} from '../../@types/size';
 
 export interface InputProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  icon?: React.ReactNode;
+  icon?: LucideIcon;
   iconPosition?: 'left' | 'right';
+  iconClassName?: string;
+  iconAriaLabel?: string;
   size?: Size;
   inputClassName?: string;
   className?: string;
@@ -24,6 +31,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     {
       icon,
       iconPosition = 'left',
+      iconClassName,
+      iconAriaLabel,
       size = 'md',
       className,
       inputClassName,
@@ -41,25 +50,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       className,
     );
 
-    const sizeClasses = {
-      sm: {
-        icon: 'text-sm',
-        iconLeft: 'left-2',
-        iconRight: 'right-2',
-      },
-      md: {
-        icon: 'text-base',
-        iconLeft: 'left-3',
-        iconRight: 'right-3',
-      },
-      lg: {
-        icon: 'text-lg',
-        iconLeft: 'left-4',
-        iconRight: 'right-4',
-      },
-    };
-
-    const currentSize = sizeClasses[size];
+    const currentSize = inputIconSizeClasses[size];
 
     const inputClass = clsx(
       'block rounded-md border shadow-sm w-full',
@@ -80,25 +71,18 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       !disabled && 'text-gray-500',
     );
 
-    const hasAccessibilityAttributes = (element: React.ReactElement) => {
-      const props = element.props as Record<string, unknown>;
-      const type = element.type as { displayName?: string };
-
-      return (
-        props['aria-label'] || props.role || type.displayName === 'Spinner'
-      );
-    };
-
     return (
       <div className={containerClass}>
-        {hasIcon && (
+        {hasIcon && icon && (
           <span
             className={iconWrapperClass}
-            aria-hidden={
-              !(React.isValidElement(icon) && hasAccessibilityAttributes(icon))
-            }
+            aria-hidden={!iconAriaLabel}
+            aria-label={iconAriaLabel}
           >
-            {icon}
+            {React.createElement(icon, {
+              size: iconSizeValues[size],
+              className: iconClassName,
+            })}
           </span>
         )}
         <input

--- a/lib/atoms/Radio/Radio.tsx
+++ b/lib/atoms/Radio/Radio.tsx
@@ -44,10 +44,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
     const radioId = useStableId(id);
     const currentSize = radioSizeClasses[size];
 
-    // ✅ FIXED: Simplified control pattern - let browser handle radio groups
     const isControlled = checked !== undefined;
-    
-    // ✅ FIXED: Proper TypeScript typing
+
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (rest.onChange) rest.onChange(e);
     };
@@ -57,8 +55,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
         id={radioId}
         type="radio"
         ref={ref}
-        checked={isControlled ? checked : undefined} // ✅ Let browser handle uncontrolled
-        defaultChecked={!isControlled ? defaultChecked : undefined} // ✅ Only set when uncontrolled
+        checked={isControlled ? checked : undefined} // Let browser handle uncontrolled
+        defaultChecked={!isControlled ? defaultChecked : undefined} // Only set when uncontrolled
         onChange={handleChange}
         value={value}
         className={clsx(

--- a/lib/atoms/Radio/Radio.tsx
+++ b/lib/atoms/Radio/Radio.tsx
@@ -18,6 +18,7 @@ export interface RadioProps
   size?: Size;
   checked?: boolean;
   defaultChecked?: boolean;
+  value?: string; // Make value explicit for proper grouping
 }
 
 /**
@@ -35,6 +36,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       className,
       labelClassName,
       wrapperClassName,
+      value,
       ...rest
     },
     ref,
@@ -42,15 +44,11 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
     const radioId = useStableId(id);
     const currentSize = radioSizeClasses[size];
 
-    // Controlled/uncontrolled
+    // ✅ FIXED: Simplified control pattern - let browser handle radio groups
     const isControlled = checked !== undefined;
-    const [internalChecked, setInternalChecked] = React.useState(
-      defaultChecked ?? false,
-    );
-    const inputChecked = isControlled ? checked : internalChecked;
-
-    const handleChange = (e) => {
-      if (!isControlled) setInternalChecked(e.target.checked);
+    
+    // ✅ FIXED: Proper TypeScript typing
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (rest.onChange) rest.onChange(e);
     };
 
@@ -59,8 +57,10 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
         id={radioId}
         type="radio"
         ref={ref}
-        checked={inputChecked}
+        checked={isControlled ? checked : undefined} // ✅ Let browser handle uncontrolled
+        defaultChecked={!isControlled ? defaultChecked : undefined} // ✅ Only set when uncontrolled
         onChange={handleChange}
+        value={value}
         className={clsx(
           'text-indigo-600 focus:ring-2 focus:ring-indigo-500 border-gray-300 rounded-full',
           currentSize.radio,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,6 +16,7 @@ export { Image } from './atoms/Image/Image';
 export { Input } from './atoms/Input/Input';
 export { InputField } from './molecules/InputField/InputField';
 export { Label } from './atoms/Label/Label';
+export { Link } from './atoms/Link/Link';
 export { ProgressBar } from './atoms/ProgressBar/ProgressBar';
 export { Radio } from './atoms/Radio/Radio';
 export { RadioGroup } from './molecules/RadioGroup/RadioGroup';

--- a/lib/molecules/InputField/InputField.test.tsx
+++ b/lib/molecules/InputField/InputField.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Search } from 'lucide-react';
@@ -59,14 +60,10 @@ describe('InputField', () => {
   });
 
   it('renders icon if provided', () => {
-    render(
-      <InputField
-        label="Search"
-        icon={<Search data-testid="icon" />}
-        placeholder="Search..."
-      />,
-    );
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    render(<InputField label="Search" icon={Search} placeholder="Search..." />);
+    // The icon should be rendered inside the input
+    const input = screen.getByLabelText('Search');
+    expect(input.parentElement?.querySelector('svg')).toBeInTheDocument();
   });
 
   it('removes input padding when no icon is provided', () => {

--- a/lib/molecules/RadioGroup/RadioGroup.tsx
+++ b/lib/molecules/RadioGroup/RadioGroup.tsx
@@ -85,6 +85,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
             checked={selected === option.value}
             onChange={handleChange(option.value)}
             name={groupName}
+            value={option.value}
             disabled={option.disabled}
             {...radioProps}
           />

--- a/lib/molecules/Search/Search.test.tsx
+++ b/lib/molecules/Search/Search.test.tsx
@@ -68,7 +68,8 @@ describe('Search', () => {
 
   it('applies custom className', () => {
     render(<Search className="custom-class" placeholder={placeholder} />);
-    const inputWrapper = screen.getByPlaceholderText(placeholder).parentElement;
-    expect(inputWrapper).toHaveClass('custom-class');
+    const searchWrapper =
+      screen.getByPlaceholderText(placeholder).parentElement?.parentElement;
+    expect(searchWrapper).toHaveClass('custom-class');
   });
 });

--- a/lib/molecules/Search/Search.tsx
+++ b/lib/molecules/Search/Search.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { Input } from '../../atoms/Input/Input';
 import type { InputProps } from '../../atoms/Input/Input';
-import { Icon } from '../../atoms/Icon/Icon';
 import { Spinner } from '../../atoms/Spinner/Spinner';
 
 import SearchIcon from 'lucide-react/icons/search';
 
-export interface SearchProps extends Omit<InputProps, 'icon' | 'iconPosition'> {
+export interface SearchProps
+  extends Omit<InputProps, 'icon' | 'iconPosition' | 'iconClassName'> {
   loading?: boolean;
   iconPosition?: 'left' | 'right';
   className?: string;
@@ -19,22 +19,31 @@ export interface SearchProps extends Omit<InputProps, 'icon' | 'iconPosition'> {
  * Shows a search icon and an optional loading spinner.
  */
 export const Search = React.forwardRef<HTMLInputElement, SearchProps>(
-  ({ loading = false, iconPosition = 'left', disabled, ...props }, ref) => {
-    const icon = loading ? (
-      <Spinner size="sm" className="mr-1" />
-    ) : (
-      <Icon icon={SearchIcon} size={18} aria-label="Search" />
-    );
-
+  (
+    { loading = false, iconPosition = 'left', disabled, className, ...props },
+    ref,
+  ) => {
     return (
-      <Input
-        ref={ref}
-        icon={icon}
-        iconPosition={iconPosition}
-        disabled={disabled || loading}
-        aria-busy={loading}
-        {...props}
-      />
+      <div className={`relative ${className || ''}`}>
+        <Input
+          ref={ref}
+          icon={SearchIcon}
+          iconAriaLabel="Search"
+          iconPosition={iconPosition}
+          disabled={disabled || loading}
+          aria-busy={loading}
+          {...props}
+        />
+        {loading && (
+          <div
+            className={`absolute inset-y-0 flex items-center ${
+              iconPosition === 'left' ? 'left-3' : 'right-3'
+            }`}
+          >
+            <Spinner size="sm" />
+          </div>
+        )}
+      </div>
     );
   },
 );

--- a/lib/molecules/Select/Select.tsx
+++ b/lib/molecules/Select/Select.tsx
@@ -10,7 +10,6 @@ import ChevronDown from 'lucide-react/icons/chevron-down';
 import clsx from 'clsx';
 
 import { Input } from '../../atoms/Input/Input';
-import { Icon } from '../../atoms/Icon/Icon';
 import { Label } from '../../atoms/Label/Label';
 import { useStableId } from '../../hooks/useStableId/useStableId';
 import type { Size } from '../../@types/size';
@@ -143,16 +142,11 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
             disabled={disabled}
             size={size}
             className={clsx('cursor-pointer', inputClassName)}
-            icon={
-              <Icon
-                icon={ChevronDown}
-                size={16}
-                className={clsx(
-                  'transition-transform duration-200',
-                  isOpen && 'rotate-180',
-                )}
-              />
-            }
+            icon={ChevronDown}
+            iconClassName={clsx(
+              'transition-transform duration-200',
+              isOpen && 'rotate-180',
+            )}
             iconPosition="right"
           />
         </div>


### PR DESCRIPTION
# Complete LucideIcon Standardization and Input Component Enhancement

## Overview

Completes the LucideIcon standardization across all components and enhances the Input component with scalable icon sizing and accessibility improvements.

## Key Changes

### Input Component Overhaul
- **Standardized icon prop**: `React.ReactNode` → `LucideIcon` for consistency
- **Added accessibility**: `iconAriaLabel` prop for semantic icons
- **Added customization**: `iconClassName` prop for styling flexibility
- **Centralized sizing**: Removed hardcoded values, uses design system

### Enhanced Size System  
- **iconSizeValues**: Consistent sizing (sm: 16px, md: 20px, lg: 24px)
- **inputIconSizeClasses**: Scalable positioning for Input components
- **Future-proof**: Foundation for consistent icon sizing across all components

### Component Updates
- **Search**: Enhanced loading overlay with proper accessibility
- **Select**: LucideIcon support with preserved rotation animations
- **InputField**: Inherits new Input capabilities seamlessly

## Migration Required

**Breaking Change**: Icon props now expect component references instead of JSX elements.

```tsx
// Before
<Input icon={<Search />} />
<Search loading icon={<Spinner />} />

// After  
<Input icon={Search} />
<Search loading />
```

## Benefits

- **Consistency**: All icon props use same LucideIcon pattern
- **Performance**: No unnecessary JSX element creation
- **Scalability**: Centralized sizing scales across component library
- **Accessibility**: Better semantic icon support
- **DX**: Cleaner API, easier to use


A component is **done** when:

- [x] Follows Component-Driven Development
- [x] Typed with defaults
- [x] Uses Tailwind CSS
- [x] Supports `className` for custom styles
- [x] Component is documented and has Storybook stories
- [x] Has unit tests and tests are passing
- [x] Passes build
- [x] Aria compliant (accessible)
- [x] Component is exported
